### PR TITLE
Add support to multi project repositories in fetch jars

### DIFF
--- a/src/services/BuildRequester.groovy
+++ b/src/services/BuildRequester.groovy
@@ -66,7 +66,9 @@ script:
   - mvn package -DskipTests
 
 before_deploy:
-    - cd /home/travis/build/${owner}/${trimmedProjectName}/target
+    - mkdir build
+    - find . -name '*.jar' -exec cp {} ./build \\;
+    - cd /home/travis/build/${owner}/${trimmedProjectName}/build
     - tar -zcvf result.tar.gz *
 deploy:
   provider: releases


### PR DESCRIPTION
Muda o script de build no travis pra invés de salvar toda a pasta target, procura recursivamente por arquivos .jar em toda estrutura do projeto

Resolve #33