### PR TITLE
Integrar ferramenta de soot analysis com o framework

### DIFF
--- a/scripts/parse_to_soot.py
+++ b/scripts/parse_to_soot.py
@@ -41,18 +41,26 @@ def parse_modification(modifications):
 def generate_csv(collection):
     for elem in collection:
         result = []
+        resultReverse = []
         className = elem[CLASS_NAME]
         leftMods = elem[LEFT_MODIFICATION]
         rightMods = elem[RIGHT_MODIFICATION]
         for l in leftMods:
+            resultReverse.append(className + ",sink," + l)
             result.append(className + ",source," + l)
         for r in rightMods:
+            resultReverse.append(className + ",source," + r)
             result.append(className + ",sink," + r)
         try:
-            csvFile = open(outputPath + "/files/" + elem[PROJECT_NAME] + "/" + elem[COMMIT_SHA] + "/soot.csv", "w")
-            csvFile.write("\n".join(result))
-            csvFile.close()
+            basePath = outputPath + "/files/" + elem[PROJECT_NAME] + "/" + elem[COMMIT_SHA]
+            saveFile(basePath + "/soot.csv", result)
+            saveFile(basePath + "/soot-reverse.csv", resultReverse)
         except:
             pass
+
+def saveFile(filePath, result):
+    csvFile = open(filePath, "w")
+    csvFile.write("\n".join(result))
+    csvFile.close()
 
 exportCsv()

--- a/src/services/OutputProcessorImpl.groovy
+++ b/src/services/OutputProcessorImpl.groovy
@@ -7,6 +7,7 @@ import static main.app.MiningFramework.arguments
 import main.util.*
 import main.project.*
 import main.exception.*
+import services.soot.SootRunner
 
 class OutputProcessorImpl implements OutputProcessor {
     
@@ -23,6 +24,9 @@ class OutputProcessorImpl implements OutputProcessor {
 
             fetchBuildsScript(inputPath, outputPath, token)
             convertToSootScript(outputPath)
+
+            SootRunner runner = new SootRunner(outputPath)
+            runner.processScenarios()
         }
     }
 

--- a/src/services/soot/SootRunner.groovy
+++ b/src/services/soot/SootRunner.groovy
@@ -1,0 +1,51 @@
+
+package services.soot
+
+import main.interfaces.OutputProcessor
+
+import static main.app.MiningFramework.arguments
+import main.util.*
+import main.project.*
+import main.exception.*
+import java.nio.file.Files 
+import java.nio.file.Paths
+import java.nio.file.Path
+
+class SootRunner {
+
+    private String outputPath
+    private String sootPath 
+
+    private final String RESULTS_FILE_PATH = "/data/results-with-builds.csv"
+
+
+    SootRunner(String outputPath, String sootProjectPath) {
+        this.outputPath = outputPath
+        this.sootPath = sootProjectPath
+    }
+
+    public  void processScenarios() {
+        List<SootScenario> sootScenarios = SootScenario.readScenarios(outputPath + RESULTS_FILE_PATH);
+
+        for (scenario in sootScenarios) {
+
+            String filePath = scenario.getLinesFile(outputPath)
+            String filePathReverse = scenario.getLinesFile(outputPath)
+            String className = scenario.getClassPath(outputPath)
+
+            String analysisOutputLeftRight = runSootAnalysis(filePath, className)
+            String analysisOutputRightLeft = runSootAnalysis(filePathReverse, className)
+        }
+
+    }
+
+
+    public String runSootAnalysis (String filePath, String classPath) {
+        String cliParameters = "-csv ${filePath} -cp ${classPath}"
+        Process analysis = ProcessRunner
+            .runProcess(sootPath, "mvn", "exec:java" ,"-Dexec.mainClass=br.unb.cic.analysis.Main", "-Dexec.args=${cliParameters}")
+    
+        return analysis.getText()
+    }
+
+}

--- a/src/services/soot/SootRunner.groovy
+++ b/src/services/soot/SootRunner.groovy
@@ -25,7 +25,12 @@ class SootRunner {
     }
 
     public  void processScenarios() {
-        String resultHead = "project;class;method;commit;dataflow left right;dataflow right left;reachability left right;reachability right left\n"
+        File sootResultsFile = new File(outputPath + "/data/soot-results.csv")
+
+        if (sootResultsFile.exists()) {
+            sootResultsFile.delete()
+        }
+        sootResultsFile << "project;class;method;commit;dataflow left right;dataflow right left;reachability left right;reachability right left\n"
 
         List<SootScenario> sootScenarios = SootScenario.readScenarios(outputPath + RESULTS_FILE_PATH);
 
@@ -50,12 +55,12 @@ class SootRunner {
             boolean leftRightReachability = hasSootFlow(analysisLeftRightReachability)
             println "Result: ${leftRightReachability}"
 
-
             println "Running right left reachability analysis"
             Process analysisRightLeftReachability = runSootAnalysis(filePathReverse, classPath, DATAFLOW_MODE)
             boolean rightLeftReachability = hasSootFlow(analysisRightLeftReachability)
             println "Result: ${rightLeftReachability}"
 
+            sootResultsFile << "${scenario.toString()};${leftRightDataflow};${rightLeftDataflow};${leftRightReachability};${rightLeftReachability}\n"
         }
 
     }

--- a/src/services/soot/SootRunner.groovy
+++ b/src/services/soot/SootRunner.groovy
@@ -17,35 +17,67 @@ class SootRunner {
     private String sootPath 
 
     private final String RESULTS_FILE_PATH = "/data/results-with-builds.csv"
+    private final String DATAFLOW_MODE = "dataflow"
+    private final String REACHABILITY_MODE = "reachability"
 
-
-    SootRunner(String outputPath, String sootProjectPath) {
+    SootRunner(String outputPath) {
         this.outputPath = outputPath
-        this.sootPath = sootProjectPath
     }
 
     public  void processScenarios() {
+        String resultHead = "project;class;method;commit;dataflow left right;dataflow right left;reachability left right;reachability right left\n"
+
         List<SootScenario> sootScenarios = SootScenario.readScenarios(outputPath + RESULTS_FILE_PATH);
 
         for (scenario in sootScenarios) {
 
             String filePath = scenario.getLinesFile(outputPath)
             String filePathReverse = scenario.getLinesFile(outputPath)
-            String className = scenario.getClassPath(outputPath)
+            String classPath = scenario.getClassPath(outputPath)
 
-            String analysisOutputLeftRight = runSootAnalysis(filePath, className)
-            String analysisOutputRightLeft = runSootAnalysis(filePathReverse, className)
+            println "Running left right dataflow analysis"
+            Process analysisLeftRightDataflow = runSootAnalysis(filePath, classPath, DATAFLOW_MODE)
+            boolean leftRightDataflow = hasSootFlow(analysisLeftRightDataflow)
+            println "Result: ${leftRightDataflow}"
+
+            println "Running right left dataflow analysis"
+            Process analysisRightLeftDataflow = runSootAnalysis(filePathReverse, classPath, DATAFLOW_MODE)
+            boolean rightLeftDataflow = hasSootFlow(analysisRightLeftDataflow)
+            println "Result: ${rightLeftDataflow}"
+
+            println "Running left right reachability analysis"
+            Process analysisLeftRightReachability = runSootAnalysis(filePath, classPath, DATAFLOW_MODE)
+            boolean leftRightReachability = hasSootFlow(analysisLeftRightReachability)
+            println "Result: ${leftRightReachability}"
+
+
+            println "Running right left reachability analysis"
+            Process analysisRightLeftReachability = runSootAnalysis(filePathReverse, classPath, DATAFLOW_MODE)
+            boolean rightLeftReachability = hasSootFlow(analysisRightLeftReachability)
+            println "Result: ${rightLeftReachability}"
+
         }
 
     }
 
-
-    public String runSootAnalysis (String filePath, String classPath) {
-        String cliParameters = "-csv ${filePath} -cp ${classPath}"
-        Process analysis = ProcessRunner
-            .runProcess(sootPath, "mvn", "exec:java" ,"-Dexec.mainClass=br.unb.cic.analysis.Main", "-Dexec.args=${cliParameters}")
-    
-        return analysis.getText()
+    public boolean hasSootFlow (Process sootProcess) {
+        boolean result = true
+        sootProcess.getInputStream().eachLine {
+            if (it.stripIndent() == "No conflicts detected") {
+                result = false
+            }
+        }
+        return result
     }
 
+    public Process runSootAnalysis (String filePath, String classPath, String mode) {
+        return ProcessRunner
+            .runProcess(".", "java", "-jar" ,"dependencies/soot-analysis.jar", "-csv", filePath, "-cp", classPath, "-mode", mode)
+    }
+
+    static main (args) {
+        SootRunner runner = new SootRunner("output")
+
+        runner.processScenarios()
+    }
 }

--- a/src/services/soot/SootScenario.groovy
+++ b/src/services/soot/SootScenario.groovy
@@ -1,0 +1,86 @@
+package services.soot
+
+@Grab('com.xlson.groovycsv:groovycsv:1.3')
+import static com.xlson.groovycsv.CsvParser.parseCsv
+
+class SootScenario {
+
+    private String projectName;
+    private String className;
+    private String methodSignature;
+    private String commitSHA;
+
+    SootScenario (projectName, className, methodSignature, commitSHA) {
+        this.projectName = projectName;
+        this.className = className;
+        this.methodSignature = methodSignature;
+        this.commitSHA = commitSHA;
+    } 
+    
+    public String toString() {
+        return "${projectName};${className};${methodSignature};${commitSHA}"
+    } 
+
+    public String getScenarioDirectory (outputPath) {
+        return "${getOutputAbsolutePath(outputPath)}/files/${projectName}/${commitSHA}"
+    }
+
+    public String getLinesFile (outputPath) {
+        return "${getScenarioDirectory(outputPath)}/soot.csv"
+    }
+
+    public String getLinesReverseFile (outputPath) {
+        return "${getScenarioDirectory(outputPath)}/soot-reverse.csv"
+    }
+    
+    public String getClassPath (outputPath) {
+        File file = new File("${this.getScenarioDirectory(outputPath)}/build")
+
+        String separator = ":"
+        if (isWindows()) {
+            separator = ";"
+        }
+
+        def buildJars = file.listFiles()
+        StringBuilder result = new StringBuilder()
+
+        
+        for (int i = 0 ; i < buildJars.length ; i++) {
+            result.append(buildJars[i])
+            if (buildJars.length - 1 > i) {
+                result.append(separator)
+            }
+        }
+
+        return result.toString()
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name") == "Windows"   
+    }
+
+    private String getOutputAbsolutePath (outputPath) {
+        return (new File(outputPath)).getAbsolutePath()
+    }
+
+    static List<SootScenario> readScenarios (filePath) {
+            
+        List<SootScenario> result = new ArrayList<SootScenario>()
+        String resultsFileText = new File(filePath).getText()
+
+        def iterator = parseCsv(resultsFileText, separator:';')
+
+        for (line in iterator) {
+            String projectName = line["project"]
+            String className = line["class"]
+            String methodSignature = line["method"]
+            String commitSHA = line["merge commit"]
+
+            def scenario = new SootScenario(projectName, className, methodSignature, commitSHA);
+        
+            result.add(scenario)
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
O pull request adiciona uma integração entre o soot-analysis e o miningframework, que roda a análise de várias formas e registra em arquivo csv para cada cenário quais formas acusaram fluxos de dados.
Além disso modifica o script de parse_to_soot para disponibilizar também os casos em que right é source e left é sink.

Resolve #46  e #11 