### PR TITLE
Muda formato do arquivo de projetos

### DIFF
--- a/projects.csv
+++ b/projects.csv
@@ -1,3 +1,4 @@
 path,name
-https://github.com/jhy/jsoup
-https://github.com/jhy/jsoup,jsoupOptionalName
+https://github.com/jhy/jsoup,jsoup
+https://github.com/guilhermejccavalcanti/jFSTMerge
+https://github.com/rbonifacio/soot-analysis

--- a/projects.csv
+++ b/projects.csv
@@ -1,2 +1,2 @@
-name,path
-jsoup,https://github.com/jhy/jsoup
+path,name
+https://github.com/jhy/jsoup

--- a/projects.csv
+++ b/projects.csv
@@ -1,3 +1,3 @@
 path,name
 https://github.com/jhy/jsoup
-https://github.com/jhy/jsoup,secondJsoup
+https://github.com/jhy/jsoup,jsoupOptionalName

--- a/projects.csv
+++ b/projects.csv
@@ -1,2 +1,3 @@
 path,name
 https://github.com/jhy/jsoup
+https://github.com/jhy/jsoup,secondJsoup

--- a/src/main/arguments/InputParser.groovy
+++ b/src/main/arguments/InputParser.groovy
@@ -13,12 +13,19 @@ class InputParser {
 
         String projectsFile = new File(inputPath).getText()
         def iterator = parseCsv(projectsFile)
-        for (line in iterator) {
-            String name = line[0]
-            String path = line[1]
 
-            Project project = new Project(name, path)
-            projectList.add(project)
+        for (line in iterator) {
+            Map lineMap = line.toMap()
+
+            String path = line["path"]
+
+            if (lineMap.containsKey("name")) {
+                String name = line["name"]
+                
+                projectList.add(new Project(name, path))
+            } else {
+                projectList.add(new Project(path))
+            }
         }
 
         return projectList

--- a/src/main/project/Project.groovy
+++ b/src/main/project/Project.groovy
@@ -3,16 +3,35 @@ package main.project
 import main.util.ProcessRunner
 import main.exception.UnexpectedOutputException
 
+import java.util.regex.Pattern
+import java.util.regex.Matcher
+
 class Project {
     
     private String name
     private String path
     private boolean remote
+    static private Pattern REMOTE_REPO_PATTERN = Pattern.compile("((http|https):\\/\\/)?.+.com\\/.+\\/.+")
 
     public Project(String name, String path) {
         this.name = name
         this.path = path
-        this.remote = path.startsWith('https://github.com/')
+        
+        this.remote = checkIfPathIsUrl(path)
+    }
+
+    public Project(String path) {
+        this.path = path
+
+        this.remote = checkIfPathIsUrl(path)   
+    
+        this.name = this.getOwnerAndName()[1] 
+    }
+
+    private checkIfPathIsUrl (String path) {
+        Matcher matcher = REMOTE_REPO_PATTERN.matcher(path)
+
+        return matcher.find()
     }
 
     public ArrayList<MergeCommit> getMergeCommits(String sinceDate, String untilDate) {
@@ -105,13 +124,15 @@ class Project {
     }
 
     public String[] getOwnerAndName() {
+        String[] splitedPath = this.path.split("/");
+        String projectName = splitedPath[splitedPath.length - 1]
+        
         if (remote) {
-            String[] splitedPath = this.path.split("/");
             String projectOwner = splitedPath[splitedPath.length - 2]
-            String projectName = splitedPath[splitedPath.length - 1]
             return [projectOwner, projectName]
+        } else {
+            return ["local", projectName]
         }
-        return []
     }
 
 }


### PR DESCRIPTION
O formato agora segue mais ou menos o que foi sugerido na issue #72, mas sem omitir o link do github, pois poderia ser usados projetos em outros serviços de git.