### PR TITLE
Null merge commit ancestor bug fix

### DIFF
--- a/src/main/project/Project.groovy
+++ b/src/main/project/Project.groovy
@@ -85,16 +85,10 @@ class Project {
         def expectedOutput = ~/[0-9a-z]{7,}/
 
         String actualOutput = gitMergeBase.getText().trim()
-        if (actualOutput.isEmpty())
-            throw new UnexpectedOutputException('Git merge-base didn\'t return any output. Could not retrieve the ancestor commit.', '<commit hash>', actualOutput)
-        else {
-            actualOutput.eachLine {
-                if (it ==~ expectedOutput)
-                    return it
-                else
-                    throw new UnexpectedOutputException('Git merge-base returned an unexpected output. Could not retrieve the ancestor commit.', '<commit hash>', it)
-            }
-        }
+        if (actualOutput ==~ expectedOutput)
+            return actualOutput
+        else
+            throw new UnexpectedOutputException('Git merge-base returned an unexpected output. Could not retrieve the ancestor commit.', '<commit hash>', actualOutput)
     }
 
     private Process constructAndRunGitMergeBase(String mergeCommitSHA, String[] parentsSHA) {

--- a/src/main/project/Project.groovy
+++ b/src/main/project/Project.groovy
@@ -40,7 +40,8 @@ class Project {
         return matcher.find()
     }
 
-    ArrayList<MergeCommit> getMergeCommits(String sinceDate, String untilDate) {
+    List getMergeCommits(String sinceDate, String untilDate) {
+        ArrayList<String> skipped = new ArrayList<String>()
         ArrayList<MergeCommit> mergeCommits = new ArrayList<MergeCommit>()
         
         Process gitLog = constructAndRunGitLog(sinceDate, untilDate)
@@ -61,6 +62,7 @@ class Project {
                 } catch (UnexpectedOutputException e) {
                     println "Skipping merge commit ${SHA}"
                     println e.message
+                    skipped.add(SHA)
                 }
             } else {
                 throw new UnexpectedOutputException('Git log returned an unexpected output. Could not retrieve merge commits.', '<commit hash>-<parents hash>', it)
@@ -69,7 +71,7 @@ class Project {
         
         if(mergeCommits.isEmpty())
             println "No merge commits."
-        return mergeCommits
+        return [mergeCommits, skipped]
     }
 
     private String getSHA(String[] informations) {

--- a/src/main/util/FileManager.groovy
+++ b/src/main/util/FileManager.groovy
@@ -146,4 +146,16 @@ final class FileManager {
         }
         return filesPath
     }
+
+    static synchronized File createSpreadsheet(Path path, String name, String header) {
+        File spreadsheet = path.resolve("${name}.csv").toFile()
+        if (!spreadsheet.exists())
+            appendLineToFile(spreadsheet, header)
+
+        return spreadsheet
+    }
+
+    static synchronized void appendLineToFile(File file, String line) {
+        file << "${line}\n"
+    }
 }


### PR DESCRIPTION
The tool may launch `NullPointerException` when trying to perform some action with a given `MergeCommit` that has `null` for its `ancestor` field.

This PR fixes that by ignoring merge commits for which `git merge-base` can't compute its parents' common ancestor.