### PR TITLE
S3M's Renaming Handler Variants Comparison

### DIFF
--- a/src/main/services/util/MergeScenarioSummary.groovy
+++ b/src/main/services/util/MergeScenarioSummary.groovy
@@ -33,8 +33,8 @@ class MergeScenarioSummary {
 
         this.differenceBetweenConflictSets = [
                 CTConflicts == SFConflicts,
-                CTConflicts == SFConflicts,
-                CTConflicts == SFConflicts,
+                CTConflicts == MMConflicts,
+                CTConflicts == KBConflicts,
                 SFConflicts == MMConflicts,
                 SFConflicts == KBConflicts,
                 MMConflicts == KBConflicts


### PR DESCRIPTION
Currently, the tool verifies if the renaming handler variants reported the same conflicts by comparing the set of conflicts reported by one variant with other variants corresponding sets. But a typo causes it to miss two comparisons and count another one three times. This PR fixes that typo.