### PR TITLE
`extractMergeConflicts` function bug fix

### DIFF
--- a/src/main/services/util/MergeConflict.groovy
+++ b/src/main/services/util/MergeConflict.groovy
@@ -52,11 +52,11 @@ class MergeConflict {
             String line = mergeCodeLines.next()
 
             /* See the following conditionals as a state machine. */
-            if (StringUtils.deleteWhitespace(line).contains(MINE_CONFLICT_MARKER) && conflictArea == ConflictArea.None) {
+            if (StringUtils.deleteWhitespace(line).startsWith(MINE_CONFLICT_MARKER) && conflictArea == ConflictArea.None) {
                 conflictArea = ConflictArea.Left
-            } else if (StringUtils.deleteWhitespace(line).contains(CHANGE_CONFLICT_MARKER) && conflictArea == ConflictArea.Left) {
+            } else if (StringUtils.deleteWhitespace(line).startsWith(CHANGE_CONFLICT_MARKER) && conflictArea == ConflictArea.Left) {
                 conflictArea = ConflictArea.Right
-            } else if (StringUtils.deleteWhitespace(line).contains(YOURS_CONFLICT_MARKER) && conflictArea == ConflictArea.Right) {
+            } else if (StringUtils.deleteWhitespace(line).startsWith(YOURS_CONFLICT_MARKER) && conflictArea == ConflictArea.Right) {
                 mergeConflicts.add(new MergeConflict(leftConflictingContent.toString(), rightConflictingContent.toString()))
                 conflictArea = ConflictArea.None
             } else {


### PR DESCRIPTION
This PR fixes the `extractMergeConflicts` function bug. The function used to incorrectly identify hard-coded conflict markers in string literals as conflict delimiters. Fixes #135 