### PR TITLE
[Adjustments] Extend the CSDiff study to any set of separators and any file extension

### DIFF
--- a/dependencies/csdiff_v2.sh
+++ b/dependencies/csdiff_v2.sh
@@ -110,7 +110,7 @@ eval ${sedCommandYourFile}
 
 # Runs diff3 against the tokenized inputs, generating a tokenized merged file
 midMergedFile="${parentFolder}/mid_merged${fileExt}"
-diff3 -m "${myFile}_temp${fileExt}" "${oldFile}_temp${fileExt}" "${yourFile}_temp${fileExt}" > $midMergedFile
+diff3 -E -m "${myFile}_temp${fileExt}" "${oldFile}_temp${fileExt}" "${yourFile}_temp${fileExt}" > $midMergedFile
 
 # Removes the tokenized input files
 rm "${myFile}_temp${fileExt}"

--- a/src/main/services/dataCollectors/csDiffCollector/SpreadsheetBuilder.groovy
+++ b/src/main/services/dataCollectors/csDiffCollector/SpreadsheetBuilder.groovy
@@ -10,7 +10,7 @@ import services.util.Utils
 import java.nio.file.Path
 
 class SpreadsheetBuilder {
-    private static final String GLOBAL_SPREADSHEET_HEADER = 'project,merge commit,number of files modified for both branches,number of Merge files with conflicts,number of CSDiff files with conflicts, number of git merge files with conflicts,number of Merge conflicts,number of CSDiff conflicts,number of git merge conflicts,approaches have the same outputs,actual merge and textual (diff3 -E -m) have same output,actual merge and csdiff have same output,actual merge and git merge have same output,notes,,,'
+    private static final String GLOBAL_SPREADSHEET_HEADER = 'project,merge commit,number of files modified for both branches,number of Merge files with conflicts,number of CSDiff files with conflicts, number of git merge files with conflicts,number of Merge conflicts,number of CSDiff conflicts,number of git merge conflicts,CSDiff and [diff3 -E -m] have the same outputs,actual merge and textual (diff3 -E -m) have same output,actual merge and csdiff have same output,actual merge and git merge have same output,notes,,,'
     private static final String COMMIT_SPREADSHEET_HEADER = 'project,merge commit,file,number of Merge conflicts,number of CSDiff conflicts,Merge text = CSDiff text,Textual Text = Actual Merge Text,CSDiff Text = Actual Merge Text,Git Merge Text = Actual Merge Text'
     private static final String SPREADSHEET_NAME = 'results.csv'
 


### PR DESCRIPTION
This PR adjusts some column header texts and fix the `csdiff_v2.sh` script dependency with a command that was missing on the initial PR, #142.

Please refer to #142 for the whole documentation on the feature, as this PR is just a hotfix.