### PR TITLE
Receive diffj execution working directory from a parameter

### DIFF
--- a/src/main/services/commitFilters/MutuallyModifiedMethodsCommitFilter.groovy
+++ b/src/main/services/commitFilters/MutuallyModifiedMethodsCommitFilter.groovy
@@ -14,7 +14,15 @@ import java.util.stream.Collectors
  */
 class MutuallyModifiedMethodsCommitFilter implements CommitFilter {
 
-    private modifiedMethodsHelper = new ModifiedMethodsHelper("diffj.jar");
+    private ModifiedMethodsHelper modifiedMethodsHelper;
+
+    public MutuallyModifiedMethodsCommitFilter() {
+        this("dependencies");
+    }
+
+    public MutuallyModifiedMethodsCommitFilter(String dependenciesPath) {
+        this.modifiedMethodsHelper = new ModifiedMethodsHelper("diffj.jar", dependenciesPath);
+    }
 
     boolean applyFilter(Project project, MergeCommit mergeCommit) {
         return containsMutuallyModifiedMethods(project, mergeCommit)

--- a/src/main/services/dataCollectors/modifiedLinesCollector/ModifiedLinesCollector.groovy
+++ b/src/main/services/dataCollectors/modifiedLinesCollector/ModifiedLinesCollector.groovy
@@ -18,7 +18,11 @@ import static app.MiningFramework.arguments
 class ModifiedLinesCollector extends ModifiedLinesCollectorAbstract {
 
     public ModifiedLinesCollector() {
-        modifiedMethodsHelper = new ModifiedMethodsHelper("diffj.jar");
+        this("dependencies");
+    }
+
+    public ModifiedLinesCollector(String dependenciesPath) {
+        modifiedMethodsHelper = new ModifiedMethodsHelper("diffj.jar", dependenciesPath);
     }
 
     void collectData(Project project, MergeCommit mergeCommit) {

--- a/src/main/services/dataCollectors/modifiedLinesCollector/ModifiedLinesCollectorDynamicSemanticStudy.groovy
+++ b/src/main/services/dataCollectors/modifiedLinesCollector/ModifiedLinesCollectorDynamicSemanticStudy.groovy
@@ -22,7 +22,11 @@ class ModifiedLinesCollectorDynamicSemanticStudy extends ModifiedLinesCollectorA
     protected String localPathRevisions = ""
 
     public ModifiedLinesCollectorDynamicSemanticStudy() {
-        modifiedMethodsHelper = new ModifiedMethodsHelper("diffj-method-return-info.jar");
+        this("dependencies");
+    }
+
+    public ModifiedLinesCollectorDynamicSemanticStudy(String dependenciesPath) {
+        modifiedMethodsHelper = new ModifiedMethodsHelper("diffj-method-return-info.jar", dependenciesPath);
     }
 
     void collectData(Project project, MergeCommit mergeCommit) {

--- a/src/main/services/dataCollectors/modifiedLinesCollector/ModifiedMethodsHelper.groovy
+++ b/src/main/services/dataCollectors/modifiedLinesCollector/ModifiedMethodsHelper.groovy
@@ -14,12 +14,18 @@ import util.ProcessRunner
 class ModifiedMethodsHelper {
     
     private String diffJOption;
+    private String dependenciesPath;
     private TextualDiffParser textualDiffParser = new TextualDiffParser();
     private DiffJParser modifiedMethodsParser = new DiffJParser();
     private MethodModifiedLinesMatcher modifiedMethodsMatcher = new MethodModifiedLinesMatcher();
 
     public ModifiedMethodsHelper(String diffj) {
-        this.diffJOption = diffj
+        this(diffj, "dependencies");
+    }
+
+    public ModifiedMethodsHelper(String diffj, String dependenciesPath) {
+        this.diffJOption = diffj;
+        this.dependenciesPath = dependenciesPath;
     }
 
     public Set<ModifiedMethod> getModifiedMethods(Project project, String filePath, String ancestorSHA, String targetSHA) {
@@ -39,7 +45,7 @@ class ModifiedMethodsHelper {
     }
 
     private List<String> runDiffJ(File ancestorFile, File targetFile) {
-        Process diffJ = ProcessRunner.runProcess('dependencies', 'java', '-jar', this.diffJOption, "--brief", ancestorFile.getAbsolutePath(), targetFile.getAbsolutePath())
+        Process diffJ = ProcessRunner.runProcess(this.dependenciesPath, 'java', '-jar', this.diffJOption, "--brief", ancestorFile.getAbsolutePath(), targetFile.getAbsolutePath())
         BufferedReader reader = new BufferedReader(new InputStreamReader(diffJ.getInputStream()))
         def output = reader.readLines()
         reader.close()


### PR DESCRIPTION
# Descrição
Diretório de execução do diffj na classe ModifiedMethodsHelper alterado para ser recebido por um parâmetro;
Valor 'dependencies' mantido como padrão para manter a funcionalidade de implementações anteriores;

# Alterações
- Criação do parâmetro dependenciesPath para a classe ModifiedMethodsHelper;
- Suporte ao novo parâmetro adicionado para todos os usos da classe mencionada;